### PR TITLE
enable testing lightstep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ plugins: deps $(PLUGINS) checks
 
 deps:
 	go get -t github.com/opentracing/opentracing-go
+	go get -t github.com/lightstep/lightstep-tracer-go
 	glide update
 	glide install
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,27 +1,12 @@
-hash: a6ff906a6ad643da7b8278c1df8f7a370e381ea18fa50076c4404bfee6a172ea
-updated: 2017-12-04T12:24:25.433558693+01:00
+hash: 8d47bf6ac557337b075035b57d9417dbee7af7dd5801c8927023a4bd307b66d4
+updated: 2017-12-05T08:49:18.222243351+01:00
 imports:
 - name: github.com/gogo/protobuf
   version: 2adc21fd136931e0388e278825291678e1d98309
   subpackages:
   - proto
-- name: github.com/golang/protobuf
-  version: 6a1fa9404c0aebf36c879bc50152edcc953910d2
-  subpackages:
-  - proto
-  - ptypes
-  - ptypes/any
-  - ptypes/duration
-  - ptypes/timestamp
 - name: github.com/instana/golang-sensor
   version: 617508adcd8f9897c995c6cf771c39ac645bbad3
-- name: github.com/lightstep/lightstep-tracer-go
-  version: 8ea6e2a40aeb49f0a846212f919d156082f58e16
-  subpackages:
-  - collectorpb
-  - lightstep_thrift
-  - lightsteppb
-  - thrift_0_9_2/lib/go/thrift
 - name: github.com/looplab/fsm
   version: bcc3636384ce80a109a6039432b30ff5b82476ee
 - name: github.com/opentracing/basictracer-go
@@ -32,44 +17,4 @@ imports:
   version: b55f1ba8817240684c58106f1f2c5c664179b5e1
   subpackages:
   - tracing
-- name: golang.org/x/net
-  version: f5079bd7f6f74e23c4d65efa0f4ce14cbd6a3c0f
-  subpackages:
-  - context
-  - http2
-  - http2/hpack
-  - idna
-  - internal/timeseries
-  - lex/httplex
-  - trace
-- name: golang.org/x/text
-  version: 1cbadb444a806fd9430d14ad08967ed91da4fa0a
-  subpackages:
-  - secure/bidirule
-  - transform
-  - unicode/bidi
-  - unicode/norm
-- name: google.golang.org/genproto
-  version: 1e559d0a00eef8a9a43151db4665280bd8dd5886
-  subpackages:
-  - googleapis/rpc/status
-- name: google.golang.org/grpc
-  version: a7dba25a82d8eb0346674b4f8c9a189959fc3bf7
-  subpackages:
-  - balancer
-  - codes
-  - connectivity
-  - credentials
-  - grpclb/grpc_lb_v1/messages
-  - grpclog
-  - internal
-  - keepalive
-  - metadata
-  - naming
-  - peer
-  - resolver
-  - stats
-  - status
-  - tap
-  - transport
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,9 +2,8 @@ package: github.com/skipper-plugins/opentracing
 import:
 - package: github.com/instana/golang-sensor
   version: ~1.4.3
-#- package: github.com/lightstep/lightstep-tracer-go
-#  version: v0.14.0
 - package: github.com/zalando/skipper
   version: ~v0.9.89
 ignore:
   - github.com/opentracing/opentracing-go
+  - github.com/lightstep/lightstep-tracer-go

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -8,14 +8,6 @@ import (
 
 var pluginDir string = "./build"
 
-/* currently fails to load - need to check why ...
-func TestLoadPluginLightstep(t *testing.T) {
-	if _, err := tracing.LoadPlugin(pluginDir, []string{"tracing_lightstep", "token=123456"}); err != nil {
-		t.Errorf("failed to load plugin `lightstep`: %s", err)
-	}
-}
-*/
-
 func TestLoadPluginBasic(t *testing.T) {
 	if _, err := tracing.LoadPlugin(pluginDir, []string{"tracing_basic"}); err != nil {
 		t.Errorf("failed to load plugin `basic`: %s", err)
@@ -25,5 +17,11 @@ func TestLoadPluginBasic(t *testing.T) {
 func TestLoadPluginInstana(t *testing.T) {
 	if _, err := tracing.LoadPlugin(pluginDir, []string{"tracing_instana"}); err != nil {
 		t.Errorf("failed to load plugin `instana`: %s", err)
+	}
+}
+
+func TestLoadPluginLightstep(t *testing.T) {
+	if _, err := tracing.LoadPlugin(pluginDir, []string{"tracing_lightstep", "token=123456", "collector=some.host.name:12345"}); err != nil {
+		t.Errorf("failed to load plugin `lightstep`: %s", err)
 	}
 }

--- a/tracers/lightstep/lightstep.go
+++ b/tracers/lightstep/lightstep.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -22,14 +23,16 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 			useThrift = true
 		}
 		if strings.HasPrefix(o, "collector=") {
-			var hostPort []string
-			hostPort = strings.Split(o[10:], ":")
-			port, err := strconv.ParseInt(hostPort[1], 10, 64)
+			host, portStr, err := net.SplitHostPort(o[10:])
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse %s as int: %s", hostPort[1], err)
+				return nil, fmt.Errorf("failed to split host/port: %s", err)
+			}
+			port, err := strconv.ParseInt(portStr, 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse %s as int: %s", portStr, err)
 			}
 			collector = lightstep.Endpoint{
-				Host: hostPort[0],
+				Host: host,
 				Port: int(port),
 			}
 		}


### PR DESCRIPTION
... currently still fails with
```
--- FAIL: TestLoadPluginLightstep (0.02s)
panic: interface conversion: http.http2StreamError is not http.http2writeFramer: missing method writeFrame [recovered]
        panic: interface conversion: http.http2StreamError is not http.http2writeFramer: missing method writeFrame

goroutine 11 [running]:
testing.tRunner.func1(0xc4201f8870)
        /usr/local/go-1.9.2/src/testing/testing.go:711 +0x2d2
panic(0x837680, 0xc42038a000)
        /usr/local/go-1.9.2/src/runtime/panic.go:491 +0x283
plugin.lastmoduleinit(0xc65400, 0xc42023a5d0, 0xc672e0, 0x56, 0xc56420)
        /usr/local/go-1.9.2/src/runtime/plugin.go:60 +0x438
plugin.open(0xc420014840, 0x1a, 0x0, 0x0, 0x0)
        /usr/local/go-1.9.2/src/plugin/plugin_dlopen.go:113 +0x23a
plugin.Open(0xc420014840, 0x1a, 0x2, 0xc420014840, 0x1a)
        /usr/local/go-1.9.2/src/plugin/plugin.go:31 +0x35
github.com/skipper-plugins/opentracing/vendor/github.com/zalando/skipper/tracing.LoadPlugin(0x888c93, 0x7, 0xc42030caf0, 0x3, 0x2, 0x2850828800000008, 0x5a26567a, 0xc420031f98, 0x5d1f36)
        /home/hhecker/go/src/github.com/skipper-plugins/opentracing/vendor/github.com/zalando/skipper/tracing/tracing.go:74 +0x17a
github.com/skipper-plugins/opentracing.TestLoadPluginLightstep(0xc4201f8870)
        /home/hhecker/go/src/github.com/skipper-plugins/opentracing/plugin_test.go:24 +0x9d
testing.tRunner(0xc4201f8870, 0x89c838)
        /usr/local/go-1.9.2/src/testing/testing.go:746 +0xd0
created by testing.(*T).Run
        /usr/local/go-1.9.2/src/testing/testing.go:789 +0x2de
exit status 2
FAIL    github.com/skipper-plugins/opentracing  0.044s
```
...need to investigate why / workaround