### PR TITLE
Allow customizing the tracer service name

### DIFF
--- a/tracers/instana/instana.go
+++ b/tracers/instana/instana.go
@@ -1,13 +1,31 @@
 package main
 
 import (
+	"strings"
+
 	instana "github.com/instana/golang-sensor"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
-func InitTracer(_ []string) (opentracing.Tracer, error) {
+const (
+	defServiceName = "skipper"
+)
+
+func InitTracer(opts []string) (opentracing.Tracer, error) {
+	serviceName := defServiceName
+
+	for _, o := range opts {
+		parts := strings.SplitN(o, "=", 2)
+		switch parts[0] {
+		case "service-name":
+			if len(parts) > 1 {
+				serviceName = parts[1]
+			}
+		}
+	}
+
 	return instana.NewTracerWithOptions(&instana.Options{
-		Service:  "skipper",
+		Service:  serviceName,
 		LogLevel: instana.Error,
 	}), nil
 }

--- a/tracers/lightstep/lightstep.go
+++ b/tracers/lightstep/lightstep.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	defComponentName = "skipper"
+	defCollectorPort = 443
 )
 
 func InitTracer(opts []string) (opentracing.Tracer, error) {
@@ -27,12 +28,12 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 				componentName = parts[1]
 			}
 		case "token":
-			token = o[6:]
+			token = parts[1]
 		case "collector":
 			subparts := strings.Split(parts[1], ":")
 			host = subparts[0]
 			if len(subparts) == 1 {
-				port = 443
+				port = defCollectorPort
 			} else {
 				var err error
 				aport, err := strconv.Atoi(subparts[1])
@@ -49,7 +50,7 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 	}
 	if host == "" {
 		host = lightstep.DefaultGRPCCollectorHost
-		port = 443
+		port = defCollectorPort
 	}
 	return lightstep.NewTracer(lightstep.Options{
 		AccessToken: token,

--- a/tracers/lightstep/lightstep.go
+++ b/tracers/lightstep/lightstep.go
@@ -40,7 +40,7 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 
 			port, err = strconv.Atoi(sport)
 			if err != nil {
-				return nil, fmt.Errorf("failed to parse %s as int: %s", sport, err)
+				return nil, fmt.Errorf("failed to parse %s as int: %v", sport, err)
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds the option of customizing the tracer service name, if the option isn't provided if will set the default one: `skipper`. 

This is very useful when there are multiple skippers or when using as sidecar proxies for different services.

Here we can see the difference that can add to the traces setting the service name when we use skipper as sidecar proxy on multiple services.

Without setting the name.
![](https://i.imgur.com/g2mSU7j.png)

Setting the name:

![](https://i.imgur.com/cqFX9IC.png)

P.S. I cleaned some small parts of the code.