### PR TITLE
explicitly set the command line tag or leave it empty

### DIFF
--- a/tracers/lightstep/lightstep.go
+++ b/tracers/lightstep/lightstep.go
@@ -20,6 +20,7 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 	var port int
 	var host, token string
 	var cmdLine string
+	var logCmdLine bool
 
 	for _, o := range opts {
 		parts := strings.SplitN(o, "=", 2)
@@ -45,6 +46,7 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 			}
 		case "cmd-line":
 			cmdLine = parts[1]
+			logCmdLine = true
 		}
 	}
 
@@ -59,6 +61,12 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 		port = lightstep.DefaultSecurePort
 	}
 
+	tags := map[string]interface{}{
+		lightstep.ComponentNameKey: componentName,
+	}
+	if logCmdLine {
+		tags[lightstep.CommandLineKey] = cmdLine
+	}
 	return lightstep.NewTracer(lightstep.Options{
 		AccessToken: token,
 		Collector: lightstep.Endpoint{
@@ -66,9 +74,6 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 			Port: port,
 		},
 		UseGRPC: true,
-		Tags: map[string]interface{}{
-			lightstep.ComponentNameKey: componentName,
-			lightstep.CommandLineKey:   cmdLine,
-		},
+		Tags:    tags,
 	}), nil
 }

--- a/tracers/lightstep/lightstep.go
+++ b/tracers/lightstep/lightstep.go
@@ -19,6 +19,7 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 	componentName := defComponentName
 	var port int
 	var host, token string
+	var cmdLine string
 
 	for _, o := range opts {
 		parts := strings.SplitN(o, "=", 2)
@@ -42,6 +43,8 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse %s as int: %v", sport, err)
 			}
+		case "cmd-line":
+			cmdLine = parts[1]
 		}
 	}
 
@@ -65,6 +68,7 @@ func InitTracer(opts []string) (opentracing.Tracer, error) {
 		UseGRPC: true,
 		Tags: map[string]interface{}{
 			lightstep.ComponentNameKey: componentName,
+			lightstep.CommandLineKey:   cmdLine,
 		},
 	}), nil
 }


### PR DESCRIPTION
this PR changes the behavior of how the cmd line argument is propagated with the lightstep vendor. Currently, the lightstep client library, if it is not defined, sets the command line tag automatically. With this change, the embedding code ~~has to~~ can set the command line tag ~~, or it will be set explicitly to empty~~ .

~~Please note that this proposal introduces an incompatible change on purpose: I believe it is a surprising behavior to log the command line args. However, if you think that we should keep the current default behavior, I'm happy to change the PR.~~

UPDATE:
I changed the PR to keep the previous default